### PR TITLE
Configure Cognite Functions for OEE and Extractors

### DIFF
--- a/common/function_config_prod.yaml
+++ b/common/function_config_prod.yaml
@@ -2,4 +2,4 @@
 # configurations files in specific function folder.
 tenant_id: 16e3985b-ebe8-4e24-9da4-933e21a9fc81
 cdf_cluster: westeurope-1
-cdf_project: cdf-bootcamp-<n>-prod
+cdf_project: cdf-bootcamp-03-prod

--- a/common/function_config_test.yaml
+++ b/common/function_config_test.yaml
@@ -2,4 +2,4 @@
 # configurations files in specific function folder.
 tenant_id: 16e3985b-ebe8-4e24-9da4-933e21a9fc81
 cdf_cluster: westeurope-1
-cdf_project: cdf-bootcamp-<n>-test
+cdf_project: cdf-bootcamp-03-test

--- a/execute_rest_extractor/function_config_prod.yaml
+++ b/execute_rest_extractor/function_config_prod.yaml
@@ -5,7 +5,7 @@ owner: CDF Bootcamp Team
 cpu: 1.0
 memory: 1.5
 env_vars: {"COGNITE_BASE_URL": "https://westeurope-1.cognitedata.com",
-  "COGNITE_PROJECT": "cdf-bootcamp-<n>-prod",
+  "COGNITE_PROJECT": "cdf-bootcamp-03-prod",
   "COGNITE_TOKEN_URL": "https://login.microsoftonline.com/16e3985b-ebe8-4e24-9da4-933e21a9fc81/oauth2/v2.0/token",
   }
-data_set_id: <DATA SET ID FOR execute_rest_extractor in PROD environment>
+data_set_id: 8864484524114547

--- a/execute_rest_extractor/function_config_test.yaml
+++ b/execute_rest_extractor/function_config_test.yaml
@@ -5,7 +5,7 @@ owner: CDF Bootcamp Team
 cpu: 1.0
 memory: 1.5
 env_vars: {"COGNITE_BASE_URL": "https://westeurope-1.cognitedata.com",
-  "COGNITE_PROJECT": "cdf-bootcamp-<n>-test",
+  "COGNITE_PROJECT": "cdf-bootcamp-03-test",
   "COGNITE_TOKEN_URL": "https://login.microsoftonline.com/16e3985b-ebe8-4e24-9da4-933e21a9fc81/oauth2/v2.0/token",
   }
-data_set_id: <DATA SET ID FOR execute_rest_extractor in TEST environment>
+data_set_id: 7260788578499740

--- a/oee_timeseries/function_config_prod.yaml
+++ b/oee_timeseries/function_config_prod.yaml
@@ -4,4 +4,4 @@ description: "Function to calculate OEE"
 owner: CDF Bootcamp Team
 cpu: 1.0
 memory: 1.5
-data_set_id: <DATA SET ID FOR oee_timeseries in PROD environment>
+data_set_id: 3399396990084320

--- a/oee_timeseries/function_config_test.yaml
+++ b/oee_timeseries/function_config_test.yaml
@@ -4,4 +4,4 @@ description: "Function to calculate OEE"
 owner: CDF Bootcamp Team
 cpu: 1.0
 memory: 1.5
-data_set_id: <DATA SET ID FOR oee_timeseries in TEST environment>
+data_set_id: 6930723292718039


### PR DESCRIPTION
Setting up the cognite extractors to run on schedule on Cognite Functions (wrapper for Azure function) 

Setting up the cognite function to use the data from Timeseries to perform the OEE calculation. 